### PR TITLE
Add REQUIRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Random
 You also need the `Reachability` package.
 At the time of writing, this package is not published in Julia's package system,
 so you need to clone the repository manually.
+The following command fixes a version with known compatibility.
 
 ```julia
-pkg> add https://github.com/JuliaReach/Reachability.git
+pkg> add https://github.com/JuliaReach/Reachability.jl#6340067f382bb0547a1ad45ddefcdab2053a3bcb
 ```
 
 Finally, for cloning this repository, again use the `add` command.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,3 @@
+julia 0.6
+LazySets 1.6.0
+Reachability


### PR DESCRIPTION
This is a semi-solution. It works well for `LazySets`.
A release version in Github does not play any role for Julia's versioning. Accordingly, `Reachability` is still recognized as `v0.0.0`, so we cannot restrict it. So I just updated the command for installing the respective commit SHA.